### PR TITLE
Initialization of C++ classes

### DIFF
--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -42,6 +42,11 @@ class NodeTable
             std::cout << "table constructor" << endl;
         }
 
+        template<typename deleter>
+        explicit NodeTable(std::unique_ptr<tsk_node_table_t,deleter> & the_table) : table(the_table.release()), malloced_locally(false)
+        {
+        }
+
         ~NodeTable()
         {
             if (malloced_locally && table != NULL) {

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -110,11 +110,11 @@ class TableCollection
 int
 main()
 {
-    NodeTable nodes;
+    //NodeTable nodes;
 
-    nodes.add_row(0, 1.0);
-    nodes.add_row(0, 2.0);
-    std::cout << "Straight table: num_rows = " << nodes.get_num_rows() << endl;
+    //nodes.add_row(0, 1.0);
+    //nodes.add_row(0, 2.0);
+    //std::cout << "Straight table: num_rows = " << nodes.get_num_rows() << endl;
 
     TableCollection tables = TableCollection(10);
     std::cout << "Sequence length = " << tables.get_sequence_length() << endl;

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <sstream>
+#include <memory>
 
 #include <tskit/tables.h>
 

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -25,7 +25,7 @@ class NodeTable
 
     private:
         tsk_node_table_t *table;
-        const bool malloced_locally;
+        const bool allocated_locally;
 
         tsk_node_table_t* allocate(tsk_node_table_t * the_table)
         {
@@ -44,14 +44,14 @@ class NodeTable
         }
 
     public:
-        explicit NodeTable(tsk_node_table_t *the_table) : table(allocate(the_table)), malloced_locally(the_table != table)
+        explicit NodeTable(tsk_node_table_t *the_table) : table(allocate(the_table)), allocated_locally(the_table != table)
         {
             std::cout << "table constructor" << endl;
         }
 
         ~NodeTable()
         {
-            if (malloced_locally && table != NULL) {
+            if (allocated_locally && table != NULL) {
                 tsk_node_table_free(table);
                 delete table;
             }

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -81,7 +81,7 @@ class TableCollection
     public:
         NodeTable nodes;
 
-        TableCollection(double sequence_length)
+        explicit TableCollection(double sequence_length)
         {
             tables = (tsk_table_collection_t *) malloc(sizeof(*tables));
             if (tables == NULL) {

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -37,13 +37,9 @@ class NodeTable
         //    check_error(ret);
         //}
 
-        NodeTable(tsk_node_table_t *the_table)
+        explicit NodeTable(tsk_node_table_t *the_table) : table(the_table), malloced_locally(false)
         {
-            /* FIXME: leaking memory here because the standard constructor has already been
-             * called. Must be a way to dealing with this though. */
-            table = the_table;
             std::cout << "table constructor" << endl;
-            malloced_locally = false;
         }
 
         ~NodeTable()

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -103,7 +103,7 @@ class TableCollection
             }
         }
 
-        double get_sequence_length()
+        double get_sequence_length() const
         {
             return tables->sequence_length;
         }

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -66,7 +66,7 @@ class NodeTable
             return ret;
         }
 
-        tsk_size_t get_num_rows(void)
+        tsk_size_t get_num_rows(void) const
         {
             return table->num_rows;
         }

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -25,7 +25,7 @@ class NodeTable
 
     private:
         tsk_node_table_t *table;
-        bool malloced_locally = true;
+        const bool malloced_locally;
 
         tsk_node_table_t* allocate(tsk_node_table_t * the_table)
         {

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -81,16 +81,15 @@ class TableCollection
     public:
         NodeTable nodes;
 
-        explicit TableCollection(double sequence_length)
+        explicit TableCollection(double sequence_length) : tables(new tsk_table_collection_t{}),
+                 nodes(&tables->nodes)
         {
-            tables = (tsk_table_collection_t *) malloc(sizeof(*tables));
-            if (tables == NULL) {
+            if (tables == nullptr) {
                 throw std::runtime_error("Out of memory");
             }
             int ret = tsk_table_collection_init(tables, 0);
             check_error(ret);
             tables->sequence_length = sequence_length;
-            nodes = NodeTable(&tables->nodes);
         }
 
         ~TableCollection()

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -44,17 +44,6 @@ class NodeTable
         }
 
     public:
-        //NodeTable()
-        //{
-        //    table = (tsk_node_table_t *) malloc(sizeof(*table));
-        //    if (table == NULL) {
-        //        throw std::runtime_error("Out of memory");
-        //    }
-        //    malloced_locally = true;
-        //    int ret = tsk_node_table_init(table, 0);
-        //    check_error(ret);
-        //}
-
         explicit NodeTable(tsk_node_table_t *the_table) : table(allocate(the_table)), malloced_locally(the_table != table)
         {
             std::cout << "table constructor" << endl;

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -26,16 +26,16 @@ class NodeTable
         bool malloced_locally = true;
 
     public:
-        NodeTable()
-        {
-            table = (tsk_node_table_t *) malloc(sizeof(*table));
-            if (table == NULL) {
-                throw std::runtime_error("Out of memory");
-            }
-            malloced_locally = true;
-            int ret = tsk_node_table_init(table, 0);
-            check_error(ret);
-        }
+        //NodeTable()
+        //{
+        //    table = (tsk_node_table_t *) malloc(sizeof(*table));
+        //    if (table == NULL) {
+        //        throw std::runtime_error("Out of memory");
+        //    }
+        //    malloced_locally = true;
+        //    int ret = tsk_node_table_init(table, 0);
+        //    check_error(ret);
+        //}
 
         NodeTable(tsk_node_table_t *the_table)
         {

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -37,6 +37,8 @@ class NodeTable
                 throw std::runtime_error("Out of memory");
             }
             int ret = tsk_node_table_init(t.get(), 0);
+            // NOTE: check error is dangerous here.  If you don't
+            // use a smart pointer above, you will get a leak.
             check_error(ret);
             return t.release();
         }

--- a/c/meson.build
+++ b/c/meson.build
@@ -1,4 +1,4 @@
-project('tskit', ['c', 'cpp'], default_options: ['c_std=c99'])
+project('tskit', ['c', 'cpp'], default_options: ['c_std=c99','cpp_std=c++11'])
 
 kastore_dir=join_paths(meson.source_root(), 'kastore/c')
 add_global_arguments(['-I' + kastore_dir], language: ['c', 'cpp'])


### PR DESCRIPTION
1. Fixes memory leak.
2. Uses smart pointers during [RAII](https://en.cppreference.com/w/cpp/language/raii) so that we cannot leak RAM from constructors when things go bad.
3. Set the standard to be C++11, instead of "whatever the compiler is defaulting to today".
4. Mark non-modifying functions as "const" so that they can be called in the following context:

```cpp

void do_something(const TableCollection & tables)
{
   // Can only call functions marked const in here!
}
```
5. Attempt a copy constructor, but it is failing.