### PR TITLE
Copy constructors and namespaces

### DIFF
--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -20,173 +20,176 @@ check_error(int val)
     }
 }
 
-class NodeTable
-{
+namespace tskit {
 
-    private:
-        tsk_node_table_t *table;
-        const bool allocated_locally;
-        using node_table_ptr = std::unique_ptr<tsk_node_table_t,void(*)(tsk_node_table_t*)>;
+    class NodeTable
+    {
 
-        node_table_ptr make_empty_table()
-        {
-            node_table_ptr t(new tsk_node_table_t{},[](tsk_node_table_t* nt){delete nt;});
-            if (t.get() == NULL) {
-                throw std::runtime_error("Out of memory");
-            }
-            return t;
-        }
+        private:
+            tsk_node_table_t *table;
+            const bool allocated_locally;
+            using node_table_ptr = std::unique_ptr<tsk_node_table_t,void(*)(tsk_node_table_t*)>;
 
-        tsk_node_table_t* allocate(tsk_node_table_t * the_table)
-        {
-            if (the_table != nullptr){ return the_table; }
-
-            node_table_ptr t(make_empty_table());
-            int ret = tsk_node_table_init(t.get(), 0);
-            // NOTE: check error is dangerous here.  If you don't
-            // use a smart pointer above, you will get a leak.
-            check_error(ret);
-            return t.release();
-        }
-
-        tsk_node_table_t*copy_construct_details(const NodeTable & other)
-        {
-            if(other.allocated_locally == false)
+            node_table_ptr make_empty_table()
             {
-                // non-owning, so we share the pointer
-                // to data
-                return other.table;
+                node_table_ptr t(new tsk_node_table_t{},[](tsk_node_table_t* nt){delete nt;});
+                if (t.get() == NULL) {
+                    throw std::runtime_error("Out of memory");
+                }
+                return t;
             }
-            node_table_ptr t(make_empty_table());
-            int ret = tsk_node_table_copy(other.table, t.get(), 0);
-            check_error(ret);
-            return t.release();
-        }
 
-    public:
-        explicit NodeTable(tsk_node_table_t *the_table) : table(allocate(the_table)), allocated_locally(the_table != table)
-        {
-            std::cout << "table constructor " << endl;
-        }
-
-        NodeTable(const NodeTable & other) : table(copy_construct_details(other)), allocated_locally(other.allocated_locally)
-        {
-        }
-
-        ~NodeTable()
-        {
-            if (allocated_locally && table != NULL) {
-                tsk_node_table_free(table);
-                delete table;
-            }
-        }
-
-
-        tsk_id_t add_row(tsk_flags_t flags, double time) /* and more params */
-        {
-            tsk_id_t ret = tsk_node_table_add_row(table, flags, time, TSK_NULL,
-                    TSK_NULL, NULL, 0);
-            check_error(ret);
-            return ret;
-        }
-
-        tsk_size_t get_num_rows(void) const
-        {
-            return table->num_rows;
-        }
-
-        bool is_equal(const NodeTable & rhs) const
-        // Convenience function allowing operator==
-        // to be implemented without "friend" status.
-        {
-            return tsk_node_table_equals(this->table, rhs.table);
-        }
-        /* Etc */
-};
-
-// NOTE: this will work when placed into namespace tskit 
-// due to "argument-depdendent lookup", or ADL
-inline bool operator==(const NodeTable & lhs, const NodeTable & rhs)
-{
-    return lhs.is_equal(rhs);
-}
-
-class TableCollection
-{
-
-    private:
-        using ptr = std::unique_ptr<tsk_table_collection_t, void(*)(tsk_table_collection_t*)>;
-        ptr tables;
-
-        ptr copy_table_collection(const ptr & other_tables)
-        {
-            ptr temp(new tsk_table_collection_t{},[](tsk_table_collection_t * t){delete t;});
-            if(temp == nullptr) { throw std::runtime_error("Out of memory"); }
-            int ret = tsk_table_collection_copy(other_tables.get(), temp.get(), 0);
-            check_error(ret);
-            return temp;
-        }
-
-    public:
-        NodeTable nodes;
-
-        explicit TableCollection(double sequence_length) : tables(new tsk_table_collection_t{},[](tsk_table_collection_t *t){delete t;}),
-                 nodes(&tables->nodes)
-        {
-            if (tables == nullptr) {
-                throw std::runtime_error("Out of memory");
-            }
-            int ret = tsk_table_collection_init(tables.get(), 0);
-            // NOTE: without the smart pointer, this is a memory leak 
-            // waiting to happen.  The destructor is NOT called 
-            // if there is an exception from a constructor.
-            check_error(ret);
-            tables->sequence_length = sequence_length;
-        }
-
-        // NOTE: copy constructor for illustration purposes.
-        // Opinions vary on what it means to copy something
-        // implemented with unique_ptr--not so unique, right?
-        // But, it is a reasonable operation.
-        TableCollection(const TableCollection & other) : 
-            tables(copy_table_collection(other.tables)),
-            nodes(&tables->nodes)
-        {
-            std::cout << "copy constructor " << '\n';
-            if(tsk_table_collection_equals(tables.get(), other.tables.get()) == 0)
+            tsk_node_table_t* allocate(tsk_node_table_t * the_table)
             {
-                throw std::runtime_error("failure to copy table collection");
+                if (the_table != nullptr){ return the_table; }
+
+                node_table_ptr t(make_empty_table());
+                int ret = tsk_node_table_init(t.get(), 0);
+                // NOTE: check error is dangerous here.  If you don't
+                // use a smart pointer above, you will get a leak.
+                check_error(ret);
+                return t.release();
             }
-        }
 
-        ~TableCollection()
-        {
-            if (tables != nullptr) {
-                tsk_table_collection_free(tables.get());
+            tsk_node_table_t*copy_construct_details(const NodeTable & other)
+            {
+                if(other.allocated_locally == false)
+                {
+                    // non-owning, so we share the pointer
+                    // to data
+                    return other.table;
+                }
+                node_table_ptr t(make_empty_table());
+                int ret = tsk_node_table_copy(other.table, t.get(), 0);
+                check_error(ret);
+                return t.release();
             }
-        }
 
-        double get_sequence_length() const
-        {
-            return tables->sequence_length;
-        }
+        public:
+            explicit NodeTable(tsk_node_table_t *the_table) : table(allocate(the_table)), allocated_locally(the_table != table)
+            {
+                std::cout << "table constructor " << endl;
+            }
 
-        bool is_equal(const TableCollection & other) const
-        {
-            return tsk_table_collection_equals(this->tables.get(), other.tables.get());
-        }
-};
+            NodeTable(const NodeTable & other) : table(copy_construct_details(other)), allocated_locally(other.allocated_locally)
+            {
+            }
 
-inline bool operator==(const TableCollection & lhs, const TableCollection & rhs)
-{
-    return lhs.is_equal(rhs);
-}
+            ~NodeTable()
+            {
+                if (allocated_locally && table != NULL) {
+                    tsk_node_table_free(table);
+                    delete table;
+                }
+            }
+
+
+            tsk_id_t add_row(tsk_flags_t flags, double time) /* and more params */
+            {
+                tsk_id_t ret = tsk_node_table_add_row(table, flags, time, TSK_NULL,
+                        TSK_NULL, NULL, 0);
+                check_error(ret);
+                return ret;
+            }
+
+            tsk_size_t get_num_rows(void) const
+            {
+                return table->num_rows;
+            }
+
+            bool is_equal(const NodeTable & rhs) const
+            // Convenience function allowing operator==
+            // to be implemented without "friend" status.
+            {
+                return tsk_node_table_equals(this->table, rhs.table);
+            }
+            /* Etc */
+    };
+
+    // NOTE: this will work when placed into namespace tskit 
+    // due to "argument-depdendent lookup", or ADL
+    inline bool operator==(const NodeTable & lhs, const NodeTable & rhs)
+    {
+        return lhs.is_equal(rhs);
+    }
+
+    class TableCollection
+    {
+
+        private:
+            using ptr = std::unique_ptr<tsk_table_collection_t, void(*)(tsk_table_collection_t*)>;
+            ptr tables;
+
+            ptr copy_table_collection(const ptr & other_tables)
+            {
+                ptr temp(new tsk_table_collection_t{},[](tsk_table_collection_t * t){delete t;});
+                if(temp == nullptr) { throw std::runtime_error("Out of memory"); }
+                int ret = tsk_table_collection_copy(other_tables.get(), temp.get(), 0);
+                check_error(ret);
+                return temp;
+            }
+
+        public:
+            NodeTable nodes;
+
+            explicit TableCollection(double sequence_length) : tables(new tsk_table_collection_t{},[](tsk_table_collection_t *t){delete t;}),
+                     nodes(&tables->nodes)
+            {
+                if (tables == nullptr) {
+                    throw std::runtime_error("Out of memory");
+                }
+                int ret = tsk_table_collection_init(tables.get(), 0);
+                // NOTE: without the smart pointer, this is a memory leak 
+                // waiting to happen.  The destructor is NOT called 
+                // if there is an exception from a constructor.
+                check_error(ret);
+                tables->sequence_length = sequence_length;
+            }
+
+            // NOTE: copy constructor for illustration purposes.
+            // Opinions vary on what it means to copy something
+            // implemented with unique_ptr--not so unique, right?
+            // But, it is a reasonable operation.
+            TableCollection(const TableCollection & other) : 
+                tables(copy_table_collection(other.tables)),
+                nodes(&tables->nodes)
+            {
+                std::cout << "copy constructor " << '\n';
+                if(tsk_table_collection_equals(tables.get(), other.tables.get()) == 0)
+                {
+                    throw std::runtime_error("failure to copy table collection");
+                }
+            }
+
+            ~TableCollection()
+            {
+                if (tables != nullptr) {
+                    tsk_table_collection_free(tables.get());
+                }
+            }
+
+            double get_sequence_length() const
+            {
+                return tables->sequence_length;
+            }
+
+            bool is_equal(const TableCollection & other) const
+            {
+                return tsk_table_collection_equals(this->tables.get(), other.tables.get());
+            }
+    };
+
+    inline bool operator==(const TableCollection & lhs, const TableCollection & rhs)
+    {
+        return lhs.is_equal(rhs);
+    }
+} //namespace tskit
 
 
 int
 main()
 {
-    NodeTable nodes(nullptr);
+    tskit::NodeTable nodes(nullptr);
     nodes.add_row(0, 1.0);
     nodes.add_row(0, 2.0);
     std::cout << "Straight table: num_rows = " << nodes.get_num_rows() << endl;
@@ -194,7 +197,7 @@ main()
     auto nodes_copy(nodes);
     assert(nodes == nodes_copy);
 
-    TableCollection tables(10);
+    tskit::TableCollection tables(10);
     std::cout << "Sequence length = " << tables.get_sequence_length() << endl;
     tables.nodes.add_row(0, 1.0);
     tables.nodes.add_row(0, 2.0);

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -94,8 +94,22 @@ class NodeTable
         {
             return table->num_rows;
         }
+
+        bool is_equal(const NodeTable & rhs) const
+        // Convenience function allowing operator==
+        // to be implemented without "friend" status.
+        {
+            return tsk_node_table_equals(this->table, rhs.table);
+        }
         /* Etc */
 };
+
+// NOTE: this will work when placed into namespace tskit 
+// due to "argument-depdendent lookup", or ADL
+inline bool operator==(const NodeTable & lhs, const NodeTable & rhs)
+{
+    return lhs.is_equal(rhs);
+}
 
 class TableCollection
 {
@@ -156,7 +170,17 @@ class TableCollection
         {
             return tables->sequence_length;
         }
+
+        bool is_equal(const TableCollection & other) const
+        {
+            return tsk_table_collection_equals(this->tables.get(), other.tables.get());
+        }
 };
+
+inline bool operator==(const TableCollection & lhs, const TableCollection & rhs)
+{
+    return lhs.is_equal(rhs);
+}
 
 
 int
@@ -168,7 +192,7 @@ main()
     std::cout << "Straight table: num_rows = " << nodes.get_num_rows() << endl;
 
     auto nodes_copy(nodes);
-    assert(nodes.get_num_rows() == nodes_copy.get_num_rows());
+    assert(nodes == nodes_copy);
 
     TableCollection tables(10);
     std::cout << "Sequence length = " << tables.get_sequence_length() << endl;
@@ -181,6 +205,7 @@ main()
     auto tables_copy(tables);
     std::cout << "Sequence length of copy = " << tables_copy.get_sequence_length() << endl;
     std::cout << "Via table collection: num_rows in copy = " << tables_copy.nodes.get_num_rows() << endl;
+    assert(tables == tables_copy);
 
     return 0;
 

--- a/c/examples/cpp-experiment.cpp
+++ b/c/examples/cpp-experiment.cpp
@@ -26,19 +26,39 @@ class NodeTable
     private:
         tsk_node_table_t *table;
         const bool allocated_locally;
+        using node_table_ptr = std::unique_ptr<tsk_node_table_t,void(*)(tsk_node_table_t*)>;
+
+        node_table_ptr make_empty_table()
+        {
+            node_table_ptr t(new tsk_node_table_t{},[](tsk_node_table_t* nt){delete nt;});
+            if (t.get() == NULL) {
+                throw std::runtime_error("Out of memory");
+            }
+            return t;
+        }
 
         tsk_node_table_t* allocate(tsk_node_table_t * the_table)
         {
             if (the_table != nullptr){ return the_table; }
 
-            using node_table_ptr = std::unique_ptr<tsk_node_table_t,void(*)(tsk_node_table_t*)>;
-            node_table_ptr t(new tsk_node_table_t{},[](tsk_node_table_t* nt){delete nt;});
-            if (t.get() == NULL) {
-                throw std::runtime_error("Out of memory");
-            }
+            node_table_ptr t(make_empty_table());
             int ret = tsk_node_table_init(t.get(), 0);
             // NOTE: check error is dangerous here.  If you don't
             // use a smart pointer above, you will get a leak.
+            check_error(ret);
+            return t.release();
+        }
+
+        tsk_node_table_t*copy_construct_details(const NodeTable & other)
+        {
+            if(other.allocated_locally == false)
+            {
+                // non-owning, so we share the pointer
+                // to data
+                return other.table;
+            }
+            node_table_ptr t(make_empty_table());
+            int ret = tsk_node_table_copy(other.table, t.get(), 0);
             check_error(ret);
             return t.release();
         }
@@ -47,6 +67,10 @@ class NodeTable
         explicit NodeTable(tsk_node_table_t *the_table) : table(allocate(the_table)), allocated_locally(the_table != table)
         {
             std::cout << "table constructor " << endl;
+        }
+
+        NodeTable(const NodeTable & other) : table(copy_construct_details(other)), allocated_locally(other.allocated_locally)
+        {
         }
 
         ~NodeTable()
@@ -142,6 +166,9 @@ main()
     nodes.add_row(0, 1.0);
     nodes.add_row(0, 2.0);
     std::cout << "Straight table: num_rows = " << nodes.get_num_rows() << endl;
+
+    auto nodes_copy(nodes);
+    assert(nodes.get_num_rows() == nodes_copy.get_num_rows());
 
     TableCollection tables(10);
     std::cout << "Sequence length = " << tables.get_sequence_length() << endl;


### PR DESCRIPTION
Show how to implement some of the other ops needed for nice API.

Note that we start needing a fair number of private functions for safe initialization.  At some point, it makes sense to start hiding that stuff from the header file via the [pimpl idiom](https://en.cppreference.com/w/cpp/language/pimpl).  Hiding this stuff makes the public interface more readable by hiding how the sausage is made, and also makes the ABI more stable, in the event that we farm a bunch of this code from headers into source files.